### PR TITLE
Disable Stickler CI fixers temporarily.

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -5,7 +5,7 @@ linters:
   shellcheck:
     shell: bash
 fixers:
-  enable: true
+  enable: false
 files:
   ignore:
     - 'bower_components/*'


### PR DESCRIPTION
They should be reenabled once alice-web is merged into
monorepo.